### PR TITLE
hotfix sur les remise à 100%

### DIFF
--- a/Class/EvolizSaleOrder.php
+++ b/Class/EvolizSaleOrder.php
@@ -133,7 +133,7 @@ abstract class EvolizSaleOrder
                 'unit_price_vat_exclude' => round($unit_vat_exclude, 2),
             ];
 
-            if (($product->get_sale_price() !== null && $product->get_sale_price() > 0) && round($product->get_regular_price(), 2) > $product->get_sale_price()) {
+            if (($product->get_sale_price() !== null) && round($product->get_regular_price(), 2) > $product->get_sale_price()) {
                 if (get_option('woocommerce_prices_include_tax') !== 'yes') {
                     $newItem['rebate'] = round(((float)$unit_vat_exclude - (float)$product->get_sale_price()) * $quantity, 2);
                 } else {


### PR DESCRIPTION
Hotfix pour les remises à 100%. On avait une vérification sur le montant de l'article pour vérifier qu'il soit supérieur à 0, visiblement certains utilisateurs ont besoin de mettre des articles avec 100% de remise (pour faire un cadeau par exemple). 
Dans le cas d'une saisie HT on aura donc 0€ en pu HT et la totalité en remise, dans le cas d'une saisie TTC on aura 0€ de PU et 0€ de remise, mais il y a aura marqué "(dont de remise de x€)" de la totalité