### PR TITLE
Add option to disable invoicing

### DIFF
--- a/EvolizSettings.php
+++ b/EvolizSettings.php
@@ -111,6 +111,11 @@ abstract class EvolizSettings
                 'sanitize_callback' => __CLASS__ . '::validateSettings'
             ]);
 
+            add_settings_section("configuration_section", "Configuration", __CLASS__ . '::displayConfigurationHeader', "evoliz_settings");
+            add_settings_field("wc_evz_enable_invoicing", "Facturer les commandes", __CLASS__ . '::displayEnableInvoicing', "evoliz_settings", "configuration_section");
+
+            register_setting("evoliz_settings", "wc_evz_enable_invoicing");
+
             add_settings_section("eu_vat_section", "Options de traitement de la TVA Intracommunautaire", __CLASS__ . '::displayEuVatHeader', "evoliz_settings");
             add_settings_field("wc_evz_enable_vat_number", "Traitement de la TVA intracommunautaire", __CLASS__ . '::displayEnableVatNumber', "evoliz_settings", "eu_vat_section");
             add_settings_field("wc_evz_eu_vat_number", "Champ du numéro de TVA intracommunautaire", __CLASS__ . '::displayVatNumberFields', "evoliz_settings", "eu_vat_section");
@@ -197,6 +202,20 @@ abstract class EvolizSettings
         <input style="width: 385px;" type="text" name="evoliz_settings_credentials[<?php echo esc_attr($args['label_for']); ?>]" id="<?php echo esc_attr($args['label_for']); ?>"
                value="<?= isset($options[$args['label_for']]) ? esc_attr($options[$args['label_for']]) : '' ?>" />
         <?php
+    }
+
+    public static function displayConfigurationHeader()
+    {
+        echo "<p>Cochez l'option suivante pour que les commandes soient automatiquement transformées en factures.</p>";
+    }
+
+    public static function displayEnableInvoicing()
+    {
+        echo '<label for="wc_evz_enable_invoicing">
+            <input name="wc_evz_enable_invoicing" id="wc_evz_enable_invoicing" type="checkbox"' .
+            (esc_attr(get_option('wc_evz_enable_invoicing', 'on')) == "on" ? ' checked="checked"' : '') . '/>' .
+            '<span class="slider round"></span>
+        </label>';
     }
 
     public static function displayEuVatHeader()

--- a/Webhooks.php
+++ b/Webhooks.php
@@ -74,7 +74,7 @@ abstract class Webhooks
                         EvolizSaleOrder::findOrCreate(self::$config, $wcOrder);
                     }
 
-                    if ($wcOrder->get_payment_method() !== 'cod') {
+                    if ($wcOrder->get_payment_method() !== 'cod' && get_option('wc_evz_enable_invoicing', 'on') === 'on') {
                         EvolizSaleOrder::invoiceAndPay(self::$config, $wcOrder);
                     }
                     break;
@@ -82,7 +82,10 @@ abstract class Webhooks
                     if (!in_array($previousStatus, ['on-hold', 'processing'])) {
                         EvolizSaleOrder::findOrCreate(self::$config, $wcOrder);
                     }
-                    EvolizSaleOrder::invoiceAndPay(self::$config, $wcOrder);
+
+                    if (get_option('wc_evz_enable_invoicing', 'on') === 'on') {
+                        EvolizSaleOrder::invoiceAndPay(self::$config, $wcOrder);
+                    }
             }
 
             EvolizSettings::updateWooCommerceAppOnEvoliz(self::$config);


### PR DESCRIPTION
Ajoute une option permettant de créer uniquement des commandes sans les factures associées.
Par défaut les factures sont générées pour garder le comportement actuel.